### PR TITLE
Support accounts that start with a digit.

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -129,7 +129,7 @@ pub(super) fn parse(input: Span<'_>) -> IResult<'_, Account<'_>> {
         cut(many1_count(preceded(
             char(':'),
             preceded(
-                satisfy(char::is_uppercase),
+                satisfy(|c: char| c.is_uppercase() || c.is_ascii_digit()),
                 take_while(|c: char| c.is_alphanumeric() || c == '-'),
             ),
         ))),

--- a/tests/parser_spec.rs
+++ b/tests/parser_spec.rs
@@ -104,6 +104,7 @@ fn should_parse_balance_assertion_amount(
 #[case("2014-05-01 open Income:A", "Income:A")]
 #[case("2014-05-01 open Expenses:A", "Expenses:A")]
 #[case("2014-05-01 open Assets:Cash2", "Assets:Cash2")]
+#[case("2014-05-01 open Assets:2Cash", "Assets:2Cash")]
 #[case("2014-05-01 open Assets:Hello-world", "Assets:Hello-world")]
 #[case("2014-05-01  open  Assets:Cash", "Assets:Cash")]
 #[case("2014-05-01\topen\tAssets:Cash:Wallet", "Assets:Cash:Wallet")]
@@ -305,8 +306,6 @@ fn should_reject_invalid_input(
         "14-05-01 open Assets:Cash",
         "2014-05-05 open Assets",
         "2014-05-05 open Assets:hello",
-        "2014-05-05 open Assets:2",
-        "2014-05-05 open Assets:2Hello",
         "2014-5-01 open Assets:Cash",
         "2014-05-1 open Assets:Cash",
         "2014-00-01 open Assets:Cash",


### PR DESCRIPTION
According to
https://beancount.github.io/docs/beancount_language_syntax.html#accounts, `Each component of the account names begin with a capital letter or a number`.